### PR TITLE
Avoid printing some resource details

### DIFF
--- a/github_actions/destroy_cluster/action.yml
+++ b/github_actions/destroy_cluster/action.yml
@@ -22,7 +22,7 @@ runs:
       working-directory: ${{ inputs.repository_folder }}
       shell: bash
     - name: Terraform Destroy
-      run: terraform destroy -auto-approve
+      run: terraform destroy -auto-approve &> /dev/null
       if: ${{ always() }}
       env:   
         TF_VAR_access_key_id: ${{ inputs.osc_access_key }}


### PR DESCRIPTION
Some resources may still be alive (like VM and keypairs) for few seconds before being deleted.
We don't want to leak any keypair information at this time.

Signed-off-by: Jérôme Jutteau <jerome.jutteau@outscale.com>