### PR TITLE
Use gp2 by default

### DIFF
--- a/github_actions/deploy_cluster/README.md
+++ b/github_actions/deploy_cluster/README.md
@@ -16,12 +16,12 @@ See [action.yml](action.yml)
 | `rke_version`              | Version of rke to use                                                             | `false`  | `"v1.3.4"`                    |
 | `kubernetes_version`       | Version of the kubernetes to deploy (See https://github.com/rancher/rke/releases) | `false`  | `"v1.22.5-rancher1-1"`        |
 | `bastion_vm_type`          | Vm type of bastion instance                                                       | `false`  | `"tinav5.c4r8p1"`             |
-| `bastion_volume_type`      | Volume type of bastion instance                                                   | `false`  | `"standard"`                  |
+| `bastion_volume_type`      | Volume type of bastion instance                                                   | `false`  | `"gp2"`                  |
 | `bastion_volume_size`      | Volume size of bastion instance                                                   | `false`  | `15`	                    |
 | `bastion_volume_iops`      | Volume iops of bastion instance                                                   | `false`  | `1500`	                    |
 | `control_plane_vm_type`    | Vm type of control plane instance                                                 | `false`  | `"tinav5.c4r8p1"`             |
 | `control_plane_count`      | Number of control plane instance                                                  | `false`  | `1`                           |
-| `control_plane_volume_type`| Volume type of control plane instance                                             | `false`  | `"standard"`                  |
+| `control_plane_volume_type`| Volume type of control plane instance                                             | `false`  | `"gp2"`                  |
 | `control_plane_volume_size`| Volume size of control plane instance                                             | `false`  | `15`	                    |
 | `control_plane_volume_size`| Volume iops of control plane instance                                             | `false`  | `1500`	                    |
 | `worker_vm_type`           | Vm type of worker instance                                                        | `false`  | `"tinav5.c4r8p1"`             |

--- a/github_actions/deploy_cluster/action.yml
+++ b/github_actions/deploy_cluster/action.yml
@@ -33,7 +33,7 @@ inputs:
   bastion_volume_type:
     description: 'Volume type of bastion instance'
     required: false
-    default: "standard"
+    default: "gp2"
   bastion_volume_size:
     description: 'Volume size of bastion instance'
     required: false
@@ -53,7 +53,7 @@ inputs:
   control_plane_volume_type:
     description: 'Volume type of control plane instance'
     required: false
-    default: "standard"
+    default: "gp2"
   control_plane_volume_size:
     description: 'Volume size of control plane instance'
     required: false


### PR DESCRIPTION
Standard can lead to deployment failure due to the slow io